### PR TITLE
PR to show hacks and changes

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -1764,6 +1764,7 @@ public class DefaultCodegen implements CodegenConfig {
                             addProperties(allProperties, allRequired, refSchema);
                         } else {
                             // composition
+                            LOGGER.info("refschema" + refSchema.get$ref());
                             addProperties(properties, required, refSchema);
                         }
                     }
@@ -1895,17 +1896,19 @@ public class DefaultCodegen implements CodegenConfig {
         if (schema instanceof ComposedSchema) {
             ComposedSchema composedSchema = (ComposedSchema) schema;
 
-            for (Schema component : composedSchema.getAllOf()) {
-                addProperties(properties, required, component);
+            if (composedSchema.getAllOf() != null) {
+                for (Schema component : composedSchema.getAllOf()) {
+                    addProperties(properties, required, component);
+                }
             }
 
-            if (composedSchema.getOneOf() != null) {
-                throw new RuntimeException("Please report the issue: Cannot process oneOf (Composed Scheme) in addProperties: " + schema);
-            }
+            // if (composedSchema.getOneOf() != null) {
+            //     throw new RuntimeException("Please report the issue: Cannot process oneOf (Composed Scheme) in addProperties: " + schema);
+            // }
 
-            if (composedSchema.getAnyOf() != null) {
-                throw new RuntimeException("Please report the issue: Cannot process anyOf (Composed Schema) in addProperties: " + schema);
-            }
+            // if (composedSchema.getAnyOf() != null) {
+            //     throw new RuntimeException("Please report the issue: Cannot process anyOf (Composed Schema) in addProperties: " + schema);
+            // }
 
             return;
         }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAxiosClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAxiosClientCodegen.java
@@ -187,6 +187,12 @@ public class TypeScriptAxiosClientCodegen extends AbstractTypeScriptClientCodege
                     }
                 }
             }
+            String[] excetions = {"createdTime", "lastUpdatedTime", "uploadedTime", "deletedTime", "timestamp"};
+            for (CodegenProperty var : cm.vars) {
+                if (Boolean.TRUE.equals(var.isNumeric) && Arrays.asList(excetions).contains(var.name)) {
+                    var.dataType = "Date";
+                }
+            }
         }
         
         // Apply the model file name to the imports as well

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAxiosClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAxiosClientCodegen.java
@@ -38,6 +38,7 @@ public class TypeScriptAxiosClientCodegen extends AbstractTypeScriptClientCodege
     public static final String WITH_INTERFACES = "withInterfaces";
     public static final String SEPARATE_MODELS_AND_API = "withSeparateModelsAndApi";
     public static final String WITHOUT_PREFIX_ENUMS = "withoutPrefixEnums";
+    public static final String ENUMS_AS_UNIONS = "enumsAsUnions";
 
     protected String npmRepository = null;
 
@@ -57,6 +58,7 @@ public class TypeScriptAxiosClientCodegen extends AbstractTypeScriptClientCodege
         this.cliOptions.add(new CliOption(WITH_INTERFACES, "Setting this property to true will generate interfaces next to the default class implementations.", SchemaTypeUtil.BOOLEAN_TYPE).defaultValue(Boolean.FALSE.toString()));
         this.cliOptions.add(new CliOption(SEPARATE_MODELS_AND_API, "Put the model and api in separate folders and in separate classes", SchemaTypeUtil.BOOLEAN_TYPE).defaultValue(Boolean.FALSE.toString()));
         this.cliOptions.add(new CliOption(WITHOUT_PREFIX_ENUMS, "Don't prefix enum names with class names", SchemaTypeUtil.BOOLEAN_TYPE).defaultValue(Boolean.FALSE.toString()));
+        this.cliOptions.add(new CliOption(ENUMS_AS_UNIONS, "Generate enums using union form", SchemaTypeUtil.BOOLEAN_TYPE).defaultValue(Boolean.FALSE.toString()));
     }
 
     @Override

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAxiosClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAxiosClientCodegen.java
@@ -39,6 +39,7 @@ public class TypeScriptAxiosClientCodegen extends AbstractTypeScriptClientCodege
     public static final String SEPARATE_MODELS_AND_API = "withSeparateModelsAndApi";
     public static final String WITHOUT_PREFIX_ENUMS = "withoutPrefixEnums";
     public static final String ENUMS_AS_UNIONS = "enumsAsUnions";
+    public static final String MODELS_IN_SEPARATE_FILE = "modelsInSeparateFile";
 
     protected String npmRepository = null;
 
@@ -59,6 +60,7 @@ public class TypeScriptAxiosClientCodegen extends AbstractTypeScriptClientCodege
         this.cliOptions.add(new CliOption(SEPARATE_MODELS_AND_API, "Put the model and api in separate folders and in separate classes", SchemaTypeUtil.BOOLEAN_TYPE).defaultValue(Boolean.FALSE.toString()));
         this.cliOptions.add(new CliOption(WITHOUT_PREFIX_ENUMS, "Don't prefix enum names with class names", SchemaTypeUtil.BOOLEAN_TYPE).defaultValue(Boolean.FALSE.toString()));
         this.cliOptions.add(new CliOption(ENUMS_AS_UNIONS, "Generate enums using union form", SchemaTypeUtil.BOOLEAN_TYPE).defaultValue(Boolean.FALSE.toString()));
+        this.cliOptions.add(new CliOption(MODELS_IN_SEPARATE_FILE, "Put all models in single separate file", SchemaTypeUtil.BOOLEAN_TYPE).defaultValue(Boolean.FALSE.toString()));
     }
 
     @Override
@@ -123,6 +125,11 @@ public class TypeScriptAxiosClientCodegen extends AbstractTypeScriptClientCodege
                 modelTemplateFiles.put("model.mustache", ".ts");
                 apiTemplateFiles.put("apiInner.mustache", ".ts");
                 supportingFiles.add(new SupportingFile("modelIndex.mustache", tsModelPackage, "index.ts"));
+            }
+        } else if (additionalProperties.containsKey(MODELS_IN_SEPARATE_FILE)) {
+            boolean separate = Boolean.parseBoolean(additionalProperties.get(MODELS_IN_SEPARATE_FILE).toString());
+            if (separate) {
+                supportingFiles.add(new SupportingFile("models.mustache", "", "types.ts"));
             }
         }
 

--- a/modules/openapi-generator/src/main/resources/typescript-axios/api.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/api.mustache
@@ -1,3 +1,25 @@
+// tslint:disable
+/// <reference path="./custom.d.ts" />
+{{>licenseInfo}}
+
+{{^withSeparateModelsAndApi}}
+import * as globalImportUrl from 'url';
+import { Configuration } from './configuration';
+import globalAxios, { AxiosPromise, AxiosInstance } from 'axios';
+import { BASE_PATH, COLLECTION_FORMATS, RequestArgs, BaseAPI, RequiredError } from './base';
+
+{{^modelsInSeparateFile}}
+{{>models}}
+{{/modelsInSeparateFile}}{{#modelsInSeparateFile}}import {
 {{#models}}
-{{#model}}{{#isEnum}}{{>modelEnum}}{{/isEnum}}{{#oneOf}}{{#-first}}{{>modelOneOf}}{{/-first}}{{/oneOf}}{{^isEnum}}{{^oneOf}}{{>modelGeneric}}{{/oneOf}}{{/isEnum}}{{/model}}
+    {{#model}}{{classname}}{{/model}}{{^-last}},{{/-last}}
 {{/models}}
+} from './types';
+{{/modelsInSeparateFile}}
+{{#apiInfo}}{{#apis}}
+{{>apiInner}}
+{{/apis}}{{/apiInfo}}
+{{/withSeparateModelsAndApi}}{{#withSeparateModelsAndApi}}
+{{#apiInfo}}{{#apis}}{{#operations}}export * from './{{apiPackage}}/{{classFilename}}';
+{{/operations}}{{/apis}}{{/apiInfo}}
+{{/withSeparateModelsAndApi}}

--- a/modules/openapi-generator/src/main/resources/typescript-axios/api.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/api.mustache
@@ -1,20 +1,3 @@
-// tslint:disable
-/// <reference path="./custom.d.ts" />
-{{>licenseInfo}}
-
-{{^withSeparateModelsAndApi}}
-import * as globalImportUrl from 'url';
-import { Configuration } from './configuration';
-import globalAxios, { AxiosPromise, AxiosInstance } from 'axios';
-import { BASE_PATH, COLLECTION_FORMATS, RequestArgs, BaseAPI, RequiredError } from './base';
-
 {{#models}}
 {{#model}}{{#isEnum}}{{>modelEnum}}{{/isEnum}}{{#oneOf}}{{#-first}}{{>modelOneOf}}{{/-first}}{{/oneOf}}{{^isEnum}}{{^oneOf}}{{>modelGeneric}}{{/oneOf}}{{/isEnum}}{{/model}}
 {{/models}}
-{{#apiInfo}}{{#apis}}
-{{>apiInner}}
-{{/apis}}{{/apiInfo}}
-{{/withSeparateModelsAndApi}}{{#withSeparateModelsAndApi}}
-{{#apiInfo}}{{#apis}}{{#operations}}export * from './{{apiPackage}}/{{classFilename}}';
-{{/operations}}{{/apis}}{{/apiInfo}}
-{{/withSeparateModelsAndApi}}

--- a/modules/openapi-generator/src/main/resources/typescript-axios/modelAlias.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/modelAlias.mustache
@@ -1,0 +1,1 @@
+export type {{classname}} = {{dataType}};

--- a/modules/openapi-generator/src/main/resources/typescript-axios/modelEnum.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/modelEnum.mustache
@@ -3,7 +3,7 @@
  * @export
  * @enum {string}
  */
-export enum {{classname}} {
+{{^enumsAsUnions}}export enum {{classname}} {
 {{#allowableValues}}
 {{#enumVars}}
     {{{name}}} = {{{value}}}{{^-last}},{{/-last}}

--- a/modules/openapi-generator/src/main/resources/typescript-axios/modelEnum.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/modelEnum.mustache
@@ -3,10 +3,18 @@
  * @export
  * @enum {string}
  */
-{{^enumsAsUnions}}export enum {{classname}} {
+{{^enumsAsUnions}}export enum {{#enumName}}{{enumName}}{{/enumName}}{{^enumName}}{{classname}}{{/enumName}} {
 {{#allowableValues}}
 {{#enumVars}}
     {{{name}}} = {{{value}}}{{^-last}},{{/-last}}
 {{/enumVars}}
 {{/allowableValues}}
-}
+}{{/enumsAsUnions}}{{#enumsAsUnions}}export type {{#enumName}}{{enumName}}{{/enumName}}{{^enumName}}{{classname}}{{/enumName}} = {{#allowableValues}}{{#enumVars}}{{{value}}}{{^-last}} | {{/-last}}{{/enumVars}}{{/allowableValues}};
+
+export const {{#enumName}}{{enumName}}{{/enumName}}{{^enumName}}{{classname}}{{/enumName}} = {
+{{#allowableValues}}
+{{#enumVars}}
+    {{name}}: {{{value}}} as {{#enumName}}{{enumName}}{{/enumName}}{{^enumName}}{{classname}}{{/enumName}}{{^-last}},{{/-last}}
+{{/enumVars}}
+{{/allowableValues}}
+}{{/enumsAsUnions}}

--- a/modules/openapi-generator/src/main/resources/typescript-axios/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/modelGeneric.mustache
@@ -21,9 +21,9 @@ export interface {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{
 {{#vars}}
 {{#isEnum}}
 /**
-    * @export
-    * @enum {string}
-    */
+ * @export
+ * @enum {string}
+ */
 export enum {{enumName}} {
 {{#allowableValues}}
     {{#enumVars}}

--- a/modules/openapi-generator/src/main/resources/typescript-axios/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/modelGeneric.mustache
@@ -20,17 +20,7 @@ export interface {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{
 
 {{#vars}}
 {{#isEnum}}
-/**
- * @export
- * @enum {string}
- */
-export enum {{enumName}} {
-{{#allowableValues}}
-    {{#enumVars}}
-    {{{name}}} = {{{value}}}{{^-last}},{{/-last}}
-    {{/enumVars}}
-{{/allowableValues}}
-}
+{{>modelEnum}}
 {{/isEnum}}
 {{/vars}}
 {{/hasEnums}}

--- a/modules/openapi-generator/src/main/resources/typescript-axios/models.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/models.mustache
@@ -1,0 +1,6 @@
+{{#modelsInSeparateFile}}
+{{>licenseInfo}}
+{{/modelsInSeparateFile}}
+{{#models}}
+{{#model}}{{#isEnum}}{{>modelEnum}}{{/isEnum}}{{#oneOf}}{{#-first}}{{>modelOneOf}}{{/-first}}{{/oneOf}}{{^isEnum}}{{^oneOf}}{{>modelGeneric}}{{/oneOf}}{{/isEnum}}{{/model}}
+{{/models}}


### PR DESCRIPTION
To be able to use this generator for our api spec you need to create spec with a special version of oas-merger. (this branch https://github.com/cognitedata/openapi-spec-merger/tree/feat/convertInlineSchemasToExplicit/src)
`node src/cli.js -c .path/to/service-contracts/versions/v1/oas-config.json -f ./path/to/result.json --convertInline`

`mvn clean install` to build the project
and then
```
java -jar ./modules/openapi-generator-cli/target/openapi-generator-cli.jar generate \
-i ./path/to/api.json -g typescript-axios -o  ./path/to/result --skip-validate-spec \
--additional-properties=enumsAsUnions=true,modelsInSeparateFile=true
```
and then optionally
```
cp ./path/to/result/types.ts ./path/to/cognitesdk-js/src/types/types.ts && \
cd .path/to/cognitesdk-js/ && \
 printf '%s\n%s\n' "// Copyright 2019 Cognite AS" "$(cat ./src/types/types.ts)" > \
./src/types/types.ts && yarn lint --fix
```




To run the generation script:

Known or possible issues:

1) Not able to check if interfaces are correct because our tests don't cover 100% of schemas (I think we need some automatic tester for that, which says if schema==interface). Tests in dtsgenerator itself is not complete either, so we can't rely on them.
2) This branch contains quite a few hacks and changes. They were added to make it work with service contracts: 
Among them: 
- a few commented out lines which used to break generator somewhere on `oneOf` parsing
- hackish fix to make it possible to generate type aliases like `type GroupResponse = Group`
- fix to be able to generate alias to union of primitives, like `type a = number | string`
- hack for type mappings, like: replace `propName: type` with `propName: newType`
- commented out a few lines as they used to break a generation, don't really remember a reason now
- `--convertInline` in oas merger, which converts inline nested schemas into separate ones. 
example: 
```
"type": "object"
     properties: {
          propName: {
               "type": "object"
...
```
propName will be converted into a separate schema.

 - MODELS_IN_SEPARATE_FILE added to be able to generate `types.ts` file containing only types, separately from other sdk modules
- ENUMS_AS_UNIONS is more like a complete feature, which can be suggested as a pr to an original repo. It generates enums in a union style. Example:
```
export type CogniteanalyticsAclAction = 'READ' | 'EXECUTE' | 'LIST';

export const CogniteanalyticsAclAction = {
  READ: 'READ' as CogniteanalyticsAclAction,
  EXECUTE: 'EXECUTE' as CogniteanalyticsAclAction,
  LIST: 'LIST' as CogniteanalyticsAclAction,
};

```

The generator is completely broken and it's really hard to fix it (just my opinion)